### PR TITLE
Update recipe for our standards.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,26 +12,39 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
+    - python
     - pip
-    - python >=3.6
+    - wheel
+    - setuptools
   run:
-    - python >=3.6
+    - python
 
 test:
+  requires:
+    - pip
   commands:
-    - test -f $SP_DIR/dateutil-stubs/__init__.pyi
+    - python -m pip check
+    - test -f $SP_DIR/dateutil-stubs/__init__.pyi  # [not win]
+    - if not exist %SP_DIR%\\ateutil-stubs\\__init__.pyi exit 1  # [win] 
 
 
 about:
   home: https://github.com/python/typeshed
   summary: Typing stubs for python-dateutil
+  description: |
+    This is a PEP 561 type stub package for the python-dateutil package. 
+    It can be used by type-checking tools like mypy, pyright, pytype, 
+    PyCharm, etc. to check code that uses python-dateutil.
   license: Apache-2.0 AND MIT
   license_file: LICENSE
+  license_family: Apache
+  dev_url: https://github.com/python/typeshed/tree/main/stubs/python-dateutil
+  doc_url: https://github.com/python/typeshed/blob/main/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ test:
   commands:
     - python -m pip check
     - test -f $SP_DIR/dateutil-stubs/__init__.pyi  # [not win]
-    - if not exist %SP_DIR%\\ateutil-stubs\\__init__.pyi exit 1  # [win] 
+    - if not exist %SP_DIR%\\dateutil-stubs\\__init__.pyi exit 1  # [win] 
 
 
 about:


### PR DESCRIPTION
types-python-dateutil v2.9.0

**Destination channel:**  defaults

### Links

- [PKG-5901](https://anaconda.atlassian.net/browse/PKG-5901) 
- [Upstream repository](https://github.com/python/typeshed)
- [Upstream changelog/diff](https://github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/python-dateutil.md)
- Relevant dependency PRs:
  - This is a new dependency for [Arrow](https://anaconda.atlassian.net/browse/PKG-5694) 

### Explanation of changes:

- Forked from CF
- Update meta.yml to our recipe standards.

### Notes
- This is a stub python package and there is nothing to import. 


[PKG-5901]: https://anaconda.atlassian.net/browse/PKG-5901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ