### PR TITLE
PKG-11363-types-python-dateutil-to-main

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 18f493414c26ffba692a72369fea7a154c502646301ebfe3d56a04b3767284cb
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<38]
 


### PR DESCRIPTION
# Explanation of changes

Release `types-python-dateutil` to main channel.

Check [PKG-11363](https://anaconda.atlassian.net/browse/PKG-11363) for dependency chain

[PKG-11363]: https://anaconda.atlassian.net/browse/PKG-11363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ